### PR TITLE
Add cross-system flow support for inter-process connections

### DIFF
--- a/FPD_Complete_Schema.xsd
+++ b/FPD_Complete_Schema.xsd
@@ -22,7 +22,7 @@
     <xs:import namespace="http://www.fpbjs.net/visual"
                schemaLocation="FPD_Visual_Extension.xsd"/>
 
-    <!-- Include the base standard schema -->
+    <!-- Include the base standard schema (includes cross-system flow definitions) -->
     <xs:include schemaLocation="FPD_Schema.xsd"/>
 
 </xs:schema>

--- a/FPD_Schema.xsd
+++ b/FPD_Schema.xsd
@@ -8,6 +8,14 @@
             <xs:sequence>
                 <xs:element ref="fpb:projectInformation"/>
                 <xs:element maxOccurs="unbounded" minOccurs="1" ref="fpb:process"/>
+                <xs:element minOccurs="0" maxOccurs="1" ref="fpb:crossSystemFlows">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Optional container for flow connections between states in
+                            different processes.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:element>
             </xs:sequence>
         </xs:complexType>
     </xs:element>
@@ -344,6 +352,73 @@
                     </xs:complexType>
                 </xs:element>
             </xs:all>
+        </xs:complexType>
+    </xs:element>
+    <!-- Cross-System Flows (inter-process State-to-State connections) -->
+    <xs:element name="crossSystemFlows">
+        <xs:annotation>
+            <xs:documentation>
+                Container for flow connections between states in different processes.
+                Defined at the project level, outside of any individual process.
+                Each crossSystemFlow represents a directed connection from a state
+                in one process to a state in another process.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element maxOccurs="unbounded" minOccurs="1" ref="fpb:crossSystemFlow"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="crossSystemFlow">
+        <xs:annotation>
+            <xs:documentation>
+                A directed flow connection between two states in different processes.
+                The source and target are identified by a combination of process ID
+                and state ID (uniqueIdent), ensuring unambiguous resolution even when
+                different processes contain states with identical IDs.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:attribute name="id" type="xs:string" use="required">
+                <xs:annotation>
+                    <xs:documentation>Unique identifier for this cross-system flow</xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="flowType" type="fpb:flowType">
+                <xs:annotation>
+                    <xs:documentation>
+                        Type of flow connection. Defaults to "flow" if omitted.
+                        Only "flow", "alternativeFlow", and "parallelFlow" are
+                        semantically meaningful for cross-system connections.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="sourceProcess" type="xs:string" use="required">
+                <xs:annotation>
+                    <xs:documentation>ID of the process containing the source state (must match a process/@id)</xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="sourceState" type="xs:string" use="required">
+                <xs:annotation>
+                    <xs:documentation>Unique identifier of the source state within the source process</xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="targetProcess" type="xs:string" use="required">
+                <xs:annotation>
+                    <xs:documentation>ID of the process containing the target state (must match a process/@id, must differ from sourceProcess)</xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="targetState" type="xs:string" use="required">
+                <xs:annotation>
+                    <xs:documentation>Unique identifier of the target state within the target process</xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
+            <xs:anyAttribute namespace="##other">
+                <xs:annotation>
+                    <xs:documentation>Allows extension attributes (e.g., visual:waypoints)</xs:documentation>
+                </xs:annotation>
+            </xs:anyAttribute>
         </xs:complexType>
     </xs:element>
     <!-- Enumerations -->

--- a/README.md
+++ b/README.md
@@ -8,20 +8,70 @@ The VDI/VDE 3682 guideline defines a graphical notation for describing technical
 
 ### Schema Structure
 
-- `project` – Root element containing project metadata and processes
+- `project` – Root element containing project metadata, processes, and optional cross-system flows
 - `process` – Process views with states, process operators, technical resources, and flows
 - `state` – Products, Energy, and Information with identification and characteristics
 - `processOperator` – Transforms input states into output states
 - `technicalResource` – Resources used by process operators
 - `flow` – Connections between states and process operators (entry/exit)
+- `crossSystemFlows` – Optional container for State-to-State flows across process boundaries
 
 ## Files
 
 | File | Description |
 |------|-------------|
-| `FPD_Schema.xsd` | Core schema defining the FPD information model |
+| `FPD_Schema.xsd` | Core schema defining the FPD information model (includes cross-system flow definitions) |
 | `FPD_Visual_Extension.xsd` | Extension for visual/graphical layout information |
 | `FPD_Complete_Schema.xsd` | Combined schema importing core and visual extension |
+
+## Cross-System Flows
+
+In practice, technical systems often interact — the output of one system becomes the input of another. The VDI/VDE 3682 standard models each system as a self-contained process with its own system limit, but does not prescribe how to represent connections between systems.
+
+The `crossSystemFlows` extension in `FPD_Schema.xsd` provides a minimal, backwards-compatible mechanism for this:
+
+- Cross-system flows are defined at the **project level** (outside of any process)
+- Only **State-to-State** connections are permitted (reflecting logical material/energy/information transfer)
+- Each flow explicitly references both the **source and target process** for unambiguous ID resolution
+- The extension is **optional** — existing documents without cross-system flows remain valid
+
+### Example
+
+```xml
+<fpb:project xmlns:fpb="http://www.vdivde.de/3682">
+  <fpb:projectInformation entryPoint="dosing_module"/>
+
+  <fpb:process id="dosing_module">
+    <fpb:systemLimit id="sl_1" name="Dosing Module v01"/>
+    <fpb:states>
+      <fpb:state stateType="product">
+        <fpb:identification uniqueIdent="P5" longName="Exhaust Gas"/>
+        <!-- ... -->
+      </fpb:state>
+      <!-- ... -->
+    </fpb:states>
+    <!-- processOperators, technicalResources, flowContainer -->
+  </fpb:process>
+
+  <fpb:process id="filtration">
+    <fpb:systemLimit id="sl_2" name="Filtration"/>
+    <fpb:states>
+      <fpb:state stateType="product">
+        <fpb:identification uniqueIdent="P201" longName="Input Gas"/>
+        <!-- ... -->
+      </fpb:state>
+      <!-- ... -->
+    </fpb:states>
+    <!-- processOperators, technicalResources, flowContainer -->
+  </fpb:process>
+
+  <fpb:crossSystemFlows>
+    <fpb:crossSystemFlow id="csf_1" flowType="flow"
+        sourceProcess="dosing_module" sourceState="P5"
+        targetProcess="filtration" targetState="P201"/>
+  </fpb:crossSystemFlows>
+</fpb:project>
+```
 
 ## Implementation
 

--- a/examples/cross_system_example.xml
+++ b/examples/cross_system_example.xml
@@ -1,0 +1,144 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Example: Cross-System Flows between two VDI 3682 processes.
+
+    This document demonstrates how to model interactions between two
+    independent systems (Dosing Module and Filtration) using the
+    crossSystemFlows extension.
+
+    The dosing module produces exhaust gas (P5), which flows into the
+    filtration system as input gas (P201). This cross-system connection
+    is defined at the project level using <crossSystemFlows>.
+-->
+<fpb:project xmlns:fpb="http://www.vdivde.de/3682"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.vdivde.de/3682 ../FPD_Schema.xsd">
+
+    <fpb:projectInformation entryPoint="dosing_module"/>
+
+    <!-- ============================================================ -->
+    <!-- Process 1: Dosing Module                                     -->
+    <!-- ============================================================ -->
+    <fpb:process id="dosing_module">
+        <fpb:systemLimit id="sl_dosing" name="Dosing Module v01"/>
+        <fpb:states>
+            <fpb:state stateType="product">
+                <fpb:identification uniqueIdent="P1" longName="Medium A">
+                    <fpb:references/>
+                </fpb:identification>
+                <fpb:characteristics/>
+                <fpb:assignments/>
+                <fpb:flows>
+                    <fpb:flow id="f1">
+                        <fpb:exit id="P1"/>
+                    </fpb:flow>
+                </fpb:flows>
+            </fpb:state>
+            <fpb:state stateType="product">
+                <fpb:identification uniqueIdent="P5" longName="Exhaust Gas">
+                    <fpb:references/>
+                </fpb:identification>
+                <fpb:characteristics/>
+                <fpb:assignments/>
+                <fpb:flows>
+                    <fpb:flow id="f2">
+                        <fpb:entry id="P5"/>
+                    </fpb:flow>
+                </fpb:flows>
+            </fpb:state>
+        </fpb:states>
+        <fpb:processOperators>
+            <fpb:processOperator>
+                <fpb:identification uniqueIdent="O1" longName="Storing">
+                    <fpb:references/>
+                </fpb:identification>
+                <fpb:characteristics/>
+                <fpb:assignments/>
+                <fpb:flows>
+                    <fpb:flow id="f1">
+                        <fpb:entry id="O1"/>
+                    </fpb:flow>
+                    <fpb:flow id="f2">
+                        <fpb:exit id="O1"/>
+                    </fpb:flow>
+                </fpb:flows>
+                <fpb:usages/>
+            </fpb:processOperator>
+        </fpb:processOperators>
+        <fpb:technicalResources/>
+        <fpb:flowContainer>
+            <fpb:flow id="f1" flowType="flow"/>
+            <fpb:flow id="f2" flowType="flow"/>
+        </fpb:flowContainer>
+    </fpb:process>
+
+    <!-- ============================================================ -->
+    <!-- Process 2: Filtration                                        -->
+    <!-- ============================================================ -->
+    <fpb:process id="filtration">
+        <fpb:systemLimit id="sl_filtration" name="Filtration"/>
+        <fpb:states>
+            <fpb:state stateType="product">
+                <fpb:identification uniqueIdent="P201" longName="Input Gas">
+                    <fpb:references/>
+                </fpb:identification>
+                <fpb:characteristics/>
+                <fpb:assignments/>
+                <fpb:flows>
+                    <fpb:flow id="f201">
+                        <fpb:exit id="P201"/>
+                    </fpb:flow>
+                </fpb:flows>
+            </fpb:state>
+            <fpb:state stateType="product">
+                <fpb:identification uniqueIdent="P202" longName="Filtered Gas">
+                    <fpb:references/>
+                </fpb:identification>
+                <fpb:characteristics/>
+                <fpb:assignments/>
+                <fpb:flows>
+                    <fpb:flow id="f202">
+                        <fpb:entry id="P202"/>
+                    </fpb:flow>
+                </fpb:flows>
+            </fpb:state>
+        </fpb:states>
+        <fpb:processOperators>
+            <fpb:processOperator>
+                <fpb:identification uniqueIdent="O201" longName="Filtering">
+                    <fpb:references/>
+                </fpb:identification>
+                <fpb:characteristics/>
+                <fpb:assignments/>
+                <fpb:flows>
+                    <fpb:flow id="f201">
+                        <fpb:entry id="O201"/>
+                    </fpb:flow>
+                    <fpb:flow id="f202">
+                        <fpb:exit id="O201"/>
+                    </fpb:flow>
+                </fpb:flows>
+                <fpb:usages/>
+            </fpb:processOperator>
+        </fpb:processOperators>
+        <fpb:technicalResources/>
+        <fpb:flowContainer>
+            <fpb:flow id="f201" flowType="flow"/>
+            <fpb:flow id="f202" flowType="flow"/>
+        </fpb:flowContainer>
+    </fpb:process>
+
+    <!-- ============================================================ -->
+    <!-- Cross-System Flows                                           -->
+    <!-- ============================================================ -->
+    <fpb:crossSystemFlows>
+        <!--
+            Exhaust gas from the dosing module flows into the filtration
+            system as input gas.
+        -->
+        <fpb:crossSystemFlow id="csf_1" flowType="flow"
+            sourceProcess="dosing_module" sourceState="P5"
+            targetProcess="filtration" targetState="P201"/>
+    </fpb:crossSystemFlows>
+
+</fpb:project>


### PR DESCRIPTION
## Summary

- Adds optional `<crossSystemFlows>` element at the `<project>` level to represent directed State-to-State connections across different processes (system limits)
- Each `<crossSystemFlow>` uses explicit `sourceProcess`/`sourceState` and `targetProcess`/`targetState` attributes for unambiguous ID resolution across processes
- Fully backwards-compatible: the extension is optional (`minOccurs="0"`), so existing documents remain valid without modification

## Motivation

VDI/VDE 3682 models each system as a self-contained process with its own system limit. In practice, technical systems interact — e.g., the output product of one system becomes the input of another. The standard does not prescribe how to represent these inter-system connections in XML.

This extension provides a minimal mechanism to do so, following these design principles:
- Existing `<process>` elements remain unchanged and valid
- Cross-system flows are defined at the project level (outside processes)
- Only State-to-State connections are permitted (no ProcessOperator or TechnicalResource endpoints), reflecting logical material/energy/information transfer between systems

## Changes

| File | Change |
|------|--------|
| `FPD_Schema.xsd` | Add `<crossSystemFlows>` and `<crossSystemFlow>` element definitions; add optional reference in `<project>` |
| `FPD_Complete_Schema.xsd` | Updated comment (no structural change) |
| `README.md` | Add Cross-System Flows documentation section with usage example |
| `examples/cross_system_example.xml` | New: validated example with two processes connected by a cross-system flow |

## Example

```xml
<fpb:crossSystemFlows>
    <fpb:crossSystemFlow id="csf_1" flowType="flow"
        sourceProcess="dosing_module" sourceState="P5"
        targetProcess="filtration" targetState="P201"/>
</fpb:crossSystemFlows>
```

## Validation

- Schema loads successfully with XSD 1.1 (xmlschema library)
- Example XML validates against `FPD_Schema.xsd`
- All existing tests pass (no regressions)